### PR TITLE
Fix: remove redundant OpenRead preflight for audio download

### DIFF
--- a/GI-Subtitles/Views/MainWindow.xaml.cs
+++ b/GI-Subtitles/Views/MainWindow.xaml.cs
@@ -1145,24 +1145,31 @@ namespace GI_Subtitles.Views
                 // Download the file to a temporary file
                 using (var webClient = new WebClient())
                 {
-                    try
-                    {
-                        webClient.OpenRead(url).Close();
-                    }
-                    catch (WebException ex)
-                    {
-                        if (ex.Response is HttpWebResponse response &&
-                            response.StatusCode == HttpStatusCode.NotFound)
-                        {
-                            return;
-                        }
-                        Console.WriteLine($"Error: {ex.Message}");
-                        return;
-                    }
+                    // Set a user agent so the CDN / server does not block the request.
+                    webClient.Headers[HttpRequestHeader.UserAgent] = "GI-Subtitles/1.0";
+
                     string tempFile = Path.GetTempFileName();
                     if (tempFile != tempFilePath)
                     {
-                        webClient.DownloadFile(url, tempFile);
+                        try
+                        {
+                            webClient.DownloadFile(url, tempFile);
+                        }
+                        catch (WebException ex) when (ex.Response is HttpWebResponse response &&
+                                                      response.StatusCode == HttpStatusCode.NotFound)
+                        {
+                            Console.WriteLine($"Audio not found: {url}");
+                            try
+                            {
+                                File.Delete(tempFile);
+                            }
+                            catch
+                            {
+                                // ignore cleanup failure
+                            }
+                            return;
+                        }
+
                         StopAudio();
                         tempFilePath = tempFile;
 
@@ -1170,7 +1177,6 @@ namespace GI_Subtitles.Views
                         mediaReader = new MediaFoundationReader(tempFile);
                         waveOut.Init(mediaReader);
                         waveOut.Play();
-                        //StopAudio();
                     }
                 }
             }


### PR DESCRIPTION
## Problem

`PlayAudioFromUrl` currently calls `webClient.OpenRead(url).Close()` before the actual `DownloadFile`. This is a GET request that is discarded immediately, so every audio triggers two HTTP requests instead of one. The endpoint also returns `405 Method Not Allowed` for HEAD, so the preflight is not a cheap HEAD check.

## Solution

- Remove the `OpenRead` preflight.
- Download directly with `WebClient.DownloadFile`.
- Catch `WebException` with status `404` to skip missing audio files cleanly.
- Add a `User-Agent` header to avoid being blocked by CDN/server.

## Note

This branch is based on #11 and will show only the network fix once #11 is merged.

## Testing

- Verified with curl that the server accepts GET with the new `User-Agent` and returns `404` for unknown md5.
- Build passes (excluding unrelated WixSharp SDK project).
